### PR TITLE
Use frozen lockfile for CI dependency install

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -17,4 +17,4 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install
+      run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- enforce lockfile-strict dependency installation in CI
- update composite setup action to run `pnpm install --frozen-lockfile`

## Why
- prevents implicit lockfile updates in CI
- fails fast when lockfile and package manifests drift