### PR TITLE
Add concurrency cancellation to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify-pr:
     name: Verify PR


### PR DESCRIPTION
## Summary
- add top-level GitHub Actions concurrency configuration
- cancel in-progress runs for the same PR/workflow group when newer commits are pushed

## Why
- reduces wasted CI minutes on superseded runs
- keeps PR feedback focused on the latest commit