### PR TITLE
Harden CI checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Check out code using Git
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install tools & dependencies
         uses: ./.github/actions/setup-node-pnpm


### PR DESCRIPTION
Disable persisted checkout credentials in CI to reduce token exposure on PR runs.